### PR TITLE
Set up a GitHub action to build the repo and create a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,13 @@ on:
   push:
 
 permissions:
-  contents: write-all
+  contents: write
 
 jobs:
   build:
     name: Build on ${{matrix.os}}
     runs-on: ${{matrix.os}}
+    contents: write-all
     strategy:
       matrix:
         os: [windows-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch:
+  push
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 on:
   push:
 
+permissions:
+  contents: write-all
+
 jobs:
   build:
     name: Build on ${{matrix.os}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+    steps:
+    - name: Install cmake
+      uses: lukka/get-cmake@latest
+
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Bootstrap vcpkg
+      run:
+        .\vcpkg\bootstrap-vcpkg.bat
+
+    - name: Vcpkg Build
+      run:
+        .\vcpkg\vcpkg install --triplet x64-windows
+
+    - name: Build LogCheetah
+      run: |
+        mkdir build & cd build
+        cmake ..
+        cmake --build . --config=Release
+
+    - name: Zip Windows Release
+      if: matrix.os == 'windows-latest'
+      uses: vimtor/action-zip@v1
+      with:
+        files: build\LogCheetah\Release
+        recursive: true
+        dest: buildZipped\\LogCheetah-Windows.zip
+
+    - name: Upload Windows Artifact
+      if: matrix.os == 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: files
+        path: buildZipped\\LogCheetah-Windows.zip
+
+  create_release:
+    name: Setup Release
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: files
+
+    - name: Create Draft Release
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        prerelease: true
+        name: v0.0.0 NEW DRAFT RELEASE
+        generate_release_notes: true
+        files: |
+          LogCheetah-Windows.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on:
-  push
+  workflow_dispatch:
 
 jobs:
   build:
@@ -15,6 +15,8 @@ jobs:
 
     - name: Check out repository
       uses: actions/checkout@v3
+      with:
+        submodules: 'true'
 
     - name: Bootstrap vcpkg
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on:
-  push:
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -59,6 +59,7 @@ jobs:
     name: Setup Release
     needs: build
     runs-on: windows-latest
+    permissions: write-all
 
     steps:
     - name: Download Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Build on ${{matrix.os}}
     runs-on: ${{matrix.os}}
-    contents: write-all
+    permissions: write-all
     strategy:
       matrix:
         os: [windows-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
 
     - name: Build LogCheetah
       run: |
-        mkdir build & cd build
+        mkdir build
+        cd build
         cmake ..
         cmake --build . --config=Release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install cmake
       uses: lukka/get-cmake@latest
 
-    - name Install windows 10 sdk
+    - name: Install windows 10 sdk
       uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
 
     - name: Check out repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
     - name: Install cmake
       uses: lukka/get-cmake@latest
 
+    - name Install windows 10 sdk
+      uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+
     - name: Check out repository
       uses: actions/checkout@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 [Bb]uild/
+vcpkg_installed/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.27)
 
 project(All)
 
-include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+include(vcpkg/scripts/buildsystems/vcpkg.cmake)
 
 add_subdirectory(LogCheetah)

--- a/LogCheetah/CMakeLists.txt
+++ b/LogCheetah/CMakeLists.txt
@@ -9,8 +9,6 @@ set(CMAKE_CXX_STANDARD 20)
 find_package(glbinding CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(OpenGL REQUIRED)
-find_library(GDIPLUS gdiplus)
-find_library(GDI32 gdi32)
 
 #Compile
 add_executable(LogCheetah WIN32
@@ -49,9 +47,9 @@ target_link_libraries(LogCheetah
     PRIVATE glbinding::glbinding
     PRIVATE glbinding::glbinding-aux
     PRIVATE glm::glm
-    PRIVATE ${GDIPLUS}
-    PRIVATE ${GDI32}
     PRIVATE ${OPENGL_LIBRARIES}
+    gdiplus
+    gdi32
     wsock32
     ws2_32
     comctl32

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Supported data types:
 
 ## Building
 
-1. Install [vcpkg](https://github.com/microsoft/vcpkg/blob/master/README.md#getting-started)
-2. Run: `mkdir build & cd build`
-3. Run: `cmake ..`
-4. Run `cmake --build . --config=Release`
+This repo uses vcpkg as a submodule.  It will need bootstraped and installed prior to building normally.  Complete build steps:
+1. ```.\vcpkg\bootstrap-vcpkg.bat```
+1. ```.\vcpkg\vcpkg install --triplet x64-windows```
+1. ```mkdir build & cd build```
+1. ```cmake ..```
+1. ```cmake --build . --config=Release```
 
 
 ## Contributing

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
-    "name":"unused",
-    "dependencies":
-    [
-        "glbinding",
-        "glm"
-    ]
+  "name": "unused",
+  "dependencies": [
+    "glbinding",
+    "glm"
+  ],
+  "builtin-baseline": "dee924de74e81388140a53c32a919ecec57d20ab"
 }


### PR DESCRIPTION
- Add vcpkg as a submodule to simplify building.
- Set up a GitHub action to build the repo and create a release.
- Fix an issue with CMake config where the github build machines couldn't find the windows gdi libraries.